### PR TITLE
refactor: Add handler to api pricing client creation

### DIFF
--- a/classes/aws_api.php
+++ b/classes/aws_api.php
@@ -61,6 +61,11 @@ class aws_api {
     private $credentials;
 
     /**
+     * @var \Aws\Pricing\PricingClient for accessing the AWS Pricing List API.
+     */
+    private $pricingclient;
+
+    /**
      * aws_api constructor.
      *
      * @throws \dml_exception
@@ -95,7 +100,7 @@ class aws_api {
      *
      * @return \Aws\Pricing\PricingClient
      */
-    public function get_pricing_client($version = '2017-10-15') : PricingClient {
+    public function create_pricing_client($handler = null, $version = '2017-10-15') : PricingClient {
 
         // Set up the minimum arguments required for client.
         $args = [
@@ -104,8 +109,16 @@ class aws_api {
             'version' => $version,
         ];
 
-        $client = new PricingClient($args);
+        // Allow handler overriding for testing.
+        if ($handler != null) {
+            $args['handler'] = $handler;
+        }
 
-        return $client;
+        // Only create client if it hasn't already been done.
+        if ($this->pricingclient == null) {
+            $this->pricingclient = new PricingClient($args);
+        }
+
+        return $this->pricingclient;
     }
 }

--- a/classes/aws_api.php
+++ b/classes/aws_api.php
@@ -96,6 +96,7 @@ class aws_api {
     /**
      * Get the AWS Pricing Client for querying AWS Price List Service API.
      *
+     * @param \Aws\MockHandler|null $handler Optional handler.
      * @param string $version the AWS Pricing Client version to use for API calls.
      *
      * @return \Aws\Pricing\PricingClient

--- a/report.php
+++ b/report.php
@@ -47,7 +47,7 @@ $output = $PAGE->get_renderer('local_smartmedia');
 
 // Build the report dependencies.
 $api = new \local_smartmedia\aws_api();
-$pricingclient = new \local_smartmedia\aws_ets_pricing_client($api->get_pricing_client());
+$pricingclient = new \local_smartmedia\aws_ets_pricing_client($api->create_pricing_client());
 $locationpricing = $pricingclient->get_location_pricing(get_config('local_smartmedia', 'api_region'));
 
 echo $output->render_report($baseurl, $locationpricing, $page, $perpage, $download);

--- a/tests/aws_api_test.php
+++ b/tests/aws_api_test.php
@@ -102,13 +102,13 @@ class local_smartmedia_aws_api_testcase extends advanced_testcase {
      * @dataProvider credentials_provider
      * @throws \dml_exception
      */
-    public function test_get_pricing_client($apikey, $apisecret) {
+    public function test_create_pricing_client($apikey, $apisecret) {
 
         set_config('api_key', $apikey, 'local_smartmedia');
         set_config('api_secret', $apisecret, 'local_smartmedia');
 
         $api = new aws_api();
-        $pricingclient = $api->get_pricing_client();
+        $pricingclient = $api->create_pricing_client();
         $this->assertInstanceOf(\Aws\Pricing\PricingClient::class, $pricingclient);
 
         // Incorrect credentials should result in an AwsException when trying to use the client,


### PR DESCRIPTION
Allow pricing client creation to include a handler for testing and store the PricingClient instance in api object instance for reuse.