### PR TITLE
The messages we get from SQS can be delivered multiple times, this in…

### DIFF
--- a/classes/queue_process.php
+++ b/classes/queue_process.php
@@ -126,13 +126,13 @@ class queue_process {
             // Not only do the number of messages received vary,
             // SQS can also deliver the same message multiple times.
             foreach ($newmessages as $newmessage) {
-                $messageid = $newmessage['MessageId'];
+                $messagehash = $newmessage['MD5OfBody'];
                 $messagesiteid = $newmessage['MessageAttributes']['siteid']['StringValue'];
 
                 // We could be using the same AWS queue for multiple Moodles,
                 // so we only store messages for our Moodle.
                 if ($messagesiteid == $CFG->siteidentifier) {
-                    $messages[$messageid] = $newmessage;
+                    $messages[$messagehash] = $newmessage;
                 }
             }
         }
@@ -155,6 +155,7 @@ class queue_process {
             $record->objectkey = $messagebody->objectkey;
             $record->process = $messagebody->process;
             $record->status = $messagebody->status;
+            $record->messagehash = $message['MD5OfBody'];
             $record->message = json_encode($messagebody->message);
             $record->senttime = $messagebody->timestamp;
             $record->timecreated = time();
@@ -162,7 +163,52 @@ class queue_process {
             $messagerecords[] = $record;
         }
 
-        $DB->insert_records('local_smartmedia_queue_msgs', $messagerecords);
+        // Because AWS SQS can deliver the same messge more than once,
+        // there is a chance we might try to insert the same message into
+        // the database more than once.
+        // So try to insert all records in bulk and if that explodes,
+        // process the records one at a time.
+        $multiinsert = true;
+        try {
+            $transaction = $DB->start_delegated_transaction();
+            $DB->insert_records('local_smartmedia_queue_msgs', $messagerecords);
+            $transaction->allow_commit();
+        } catch (\dml_write_exception $e) {
+            $multiinsert = false;
+        }
+
+        // Retry inserting messages one at a time.
+        // Less efficent than the bulk insert but we can
+        // filter out the duplicate.
+        if (!$multiinsert) {
+
+            // First we rollback the multi-insert transaction.
+            try {
+                $transaction->rollback($e);
+            } catch (\dml_write_exception $e) {
+                // If error is anything else but a duplicate insert, this is unexected,
+                // so re-throw the error.
+                if (!strpos($e->getMessage(), 'locasmarqueumsgs_mes_uix')) {
+                    throw $e;
+                }
+
+            }
+
+            // Next process messages one at a time.
+            foreach ($messagerecords as $messagerecord) {
+                try {
+                    $DB->insert_record('local_smartmedia_queue_msgs', $messagerecord);
+
+                } catch (\dml_write_exception $e) {
+                    // If error is anything else but a duplicate insert, this is unexected,
+                    // so re-throw the error.
+                    if (!strpos($e->getMessage(), 'locasmarqueumsgs_mes_uix')) {
+                        throw $e;
+                    }
+                }
+
+            }
+        }
 
     }
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<XMLDB PATH="local/smartmedia/db" VERSION="20190825" COMMENT="XMLDB file for Moodle local/smartmedia to track smart media conversions"
+<XMLDB PATH="local/smartmedia/db" VERSION="20190904" COMMENT="XMLDB file for Moodle local/smartmedia to track smart media conversions"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
@@ -71,6 +71,7 @@
         <FIELD NAME="objectkey" TYPE="char" LENGTH="40" NOTNULL="true" SEQUENCE="false" COMMENT="The key of the object in the AWS S3 input bucket. This will be the same as the contenthash from the Moodle file table."/>
         <FIELD NAME="process" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="The AWS process the message pertains to"/>
         <FIELD NAME="status" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="The status code of the message"/>
+        <FIELD NAME="messagehash" TYPE="char" LENGTH="32" NOTNULL="true" SEQUENCE="false" COMMENT="MD5 hash of the message body."/>
         <FIELD NAME="message" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="The full message"/>
         <FIELD NAME="senttime" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The timestamp of when the message was sent to the queue"/>
         <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The timestamp of when this record was created"/>
@@ -78,6 +79,9 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="messagehash" UNIQUE="true" FIELDS="messagehash"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="local_smartmedia_reports" COMMENT="Various data used in smartmedia reports">
       <FIELDS>

--- a/tests/conversion_test.php
+++ b/tests/conversion_test.php
@@ -667,6 +667,7 @@ class local_smartmedia_conversion_testcase extends advanced_testcase {
         $messagerecord1->objectkey = '8d6985bd0d2abb09a444eb7066efc43678465fc0';
         $messagerecord1->process = 'StartContentModeration';
         $messagerecord1->status = 'SUCCEEDED';
+        $messagerecord1->messagehash = md5('a');
         $messagerecord1->message = '{}';
         $messagerecord1->senttime = '1566091817';
         $messagerecord1->timecreated = '1566197550';
@@ -675,6 +676,7 @@ class local_smartmedia_conversion_testcase extends advanced_testcase {
         $messagerecord2->objectkey = '8d6985bd0d2abb09a444eb7066efc43678465fc0';
         $messagerecord2->process = 'elastic_transcoder';
         $messagerecord2->status = 'COMPLETED';
+        $messagerecord2->messagehash = md5('b');
         $messagerecord2->message = '{}';
         $messagerecord2->senttime = '1566091817';
         $messagerecord2->timecreated = '1566197550';
@@ -682,6 +684,7 @@ class local_smartmedia_conversion_testcase extends advanced_testcase {
         $messagerecord3 = new \stdClass();
         $messagerecord3->objectkey = '8d6985bd0d2abb09a444eb7066efc43678465fc0';
         $messagerecord3->process = 'elastic_transcoder';
+        $messagerecord3->messagehash = md5('c');
         $messagerecord3->status = 'PROGRESSING';
         $messagerecord3->message = '{}';
         $messagerecord3->senttime = '1566091817';

--- a/tests/fixtures/queue_process_test_fixture.php
+++ b/tests/fixtures/queue_process_test_fixture.php
@@ -84,6 +84,34 @@ return array(
                     ),
                 ),
             ),
+            2 =>
+            array (
+                'MessageId' => 'ecd44ebd-d5b6-4b6f-bda6-f9374995c3ac',
+                'ReceiptHandle' => 'AQEBPWXP6D/gDYUNKrZtSMwWN9tvH/AkANg+OQKcY71YTC6RGenmm9AspWF4zJYOZA+PIwOTfoqL00iPzGCtF2ybPvcHtypRWGQ3nsR8tWR2EPNDURYCWxmvqaSQWh0tUHi9iakJewicFjsy+JOQnbI8yiq88AqhksWQzRrvgoGglUIpbyBPmSuK2wqpd5IDS4VGrMdBjlwr+VkBrCHCJs350Kl5MZw8cNPqN/YX3Mds3rKcQBKOytuMj5QP8ejW781q79nVyu9SyaDVOh3KPGSpmeUQ7upNlIRn3x12pJ4RTPZSAu1/ifiqt4je0yP9umgT16M7fzBT0p3y1Rk0RVDw8+AJ2I5FkJ19jKvkdDDDJyb5sXDFlLgIom/R94honk0bTdJSRSIiF1GB2FFCrFIwN+89pkYkKN3JvPvZXTOrXho=',
+                'MD5OfBody' => 'd2fa266e5c1f2e16dee1ff344cec4aec',
+                'Body' => '{"siteid": "wck1bOkID2Nj6mCG3bsQqUwxPz54eQaxmoodle.local", "objectkey": "SampleVideo1mb", "process": "StartLabelDetection", "status": "SUCCEEDED", "message": {"JobId": "40169f69f27719a7966c44e3b9c6bb72a064dddb50edc8ab459520283623fddc", "Status": "SUCCEEDED", "API": "StartLabelDetection", "JobTag": "1566091572480-6zh1ov", "Timestamp": 1566091618782, "Video": {"S3ObjectName": "SampleVideo1mb/conversions/SampleVideo1mb.mp4", "S3Bucket": "smt1566089892-output"}}, "timestamp": 1566091817}',
+                'Attributes' =>
+                array (
+                    'SenderId' => 'AROA2C7YAPAQNI2XBZMTN:smt1566089892_rekognition_complete',
+                    'ApproximateFirstReceiveTimestamp' => '1566091817238',
+                    'ApproximateReceiveCount' => '5',
+                    'SentTimestamp' => '1566091817238',
+                ),
+                'MD5OfMessageAttributes' => '58695f7626857aca927f4b4281ca4ae5',
+                'MessageAttributes' =>
+                array (
+                    'inputkey' =>
+                    array (
+                        'StringValue' => 'SampleVideo1mb',
+                        'DataType' => 'String',
+                    ),
+                    'siteid' =>
+                    array (
+                        'StringValue' => 'wck1bOkID2Nj6mCG3bsQqUwxPz54eQaxmoodle.local',
+                        'DataType' => 'String',
+                    ),
+                ),
+            ),
         ),
         '@metadata' =>
         array (
@@ -164,5 +192,33 @@ return array(
                 ),
             ),
         ),
+        'ecd44ebd-d5b6-4b6f-bda6-f9374995c3dd' =>
+            array (
+                    'MessageId' => 'ecd44ebd-d5b6-4b6f-bda6-f9374995c3ac',
+                    'ReceiptHandle' => 'AQEBPWXP6D/gDYUNKrZtSMwWN9tvH/AkANg+OQKcY71YTC6RGenmm9AspWF4zJYOZA+PIwOTfoqL00iPzGCtF2ybPvcHtypRWGQ3nsR8tWR2EPNDURYCWxmvqaSQWh0tUHi9iakJewicFjsy+JOQnbI8yiq88AqhksWQzRrvgoGglUIpbyBPmSuK2wqpd5IDS4VGrMdBjlwr+VkBrCHCJs350Kl5MZw8cNPqN/YX3Mds3rKcQBKOytuMj5QP8ejW781q79nVyu9SyaDVOh3KPGSpmeUQ7upNlIRn3x12pJ4RTPZSAu1/ifiqt4je0yP9umgT16M7fzBT0p3y1Rk0RVDw8+AJ2I5FkJ19jKvkdDDDJyb5sXDFlLgIom/R94honk0bTdJSRSIiF1GB2FFCrFIwN+89pkYkKN3JvPvZXTOrXho=',
+                    'MD5OfBody' => 'd2fa266e5c1f2e16dee1ff344cec4aec',
+                    'Body' => '{"siteid": "wck1bOkID2Nj6mCG3bsQqUwxPz54eQaxmoodle.local", "objectkey": "SampleVideo1mb", "process": "StartLabelDetection", "status": "SUCCEEDED", "message": {"JobId": "40169f69f27719a7966c44e3b9c6bb72a064dddb50edc8ab459520283623fddc", "Status": "SUCCEEDED", "API": "StartLabelDetection", "JobTag": "1566091572480-6zh1ov", "Timestamp": 1566091618782, "Video": {"S3ObjectName": "SampleVideo1mb/conversions/SampleVideo1mb.mp4", "S3Bucket": "smt1566089892-output"}}, "timestamp": 1566091817}',
+                    'Attributes' =>
+                    array (
+                            'SenderId' => 'AROA2C7YAPAQNI2XBZMTN:smt1566089892_rekognition_complete',
+                            'ApproximateFirstReceiveTimestamp' => '1566091817238',
+                            'ApproximateReceiveCount' => '5',
+                            'SentTimestamp' => '1566091817238',
+                    ),
+                    'MD5OfMessageAttributes' => '58695f7626857aca927f4b4281ca4ae5',
+                    'MessageAttributes' =>
+                    array (
+                            'inputkey' =>
+                            array (
+                                    'StringValue' => 'SampleVideo1mb',
+                                    'DataType' => 'String',
+                            ),
+                            'siteid' =>
+                            array (
+                                    'StringValue' => 'wck1bOkID2Nj6mCG3bsQqUwxPz54eQaxmoodle.local',
+                                    'DataType' => 'String',
+                            ),
+                    ),
+            ),
     )
 );

--- a/tests/queue_process_test.php
+++ b/tests/queue_process_test.php
@@ -84,8 +84,8 @@ class local_smartmedia_queue_process_testcase extends advanced_testcase {
         $result = $method->invoke($queueprocess);
 
         $this->assertCount(2, $result);
-        $this->assertArrayHasKey('b804a5e3-0086-4da6-be10-966ebf6083ea', $result);
-        $this->assertArrayHasKey('ecd44ebd-d5b6-4b6f-bda6-f9374995c3ac', $result);
+        $this->assertArrayHasKey('49e4e0a1b2a24b669cef908c8e3be862', $result);
+        $this->assertArrayHasKey('d2fa266e5c1f2e16dee1ff344cec4aec', $result);
     }
 
     /**
@@ -119,6 +119,7 @@ class local_smartmedia_queue_process_testcase extends advanced_testcase {
         $mock = new MockHandler();
         $mock->append(new Result(array()));
         $mock->append(new Result(array()));
+        $mock->append(new Result(array()));
 
         $queueprocess = new \local_smartmedia\queue_process();
         $queueprocess->create_client($mock);
@@ -130,7 +131,7 @@ class local_smartmedia_queue_process_testcase extends advanced_testcase {
         $method->setAccessible(true); // Allow accessing of private method.
         $result = $method->invoke($queueprocess, $messages);
 
-        $this->assertCount(2, $result);
+        $this->assertCount(3, $result);
     }
 
 }

--- a/tests/queue_process_test.php
+++ b/tests/queue_process_test.php
@@ -84,8 +84,8 @@ class local_smartmedia_queue_process_testcase extends advanced_testcase {
         $result = $method->invoke($queueprocess);
 
         $this->assertCount(2, $result);
-        $this->assertArrayHasKey('49e4e0a1b2a24b669cef908c8e3be862', $result);
-        $this->assertArrayHasKey('d2fa266e5c1f2e16dee1ff344cec4aec', $result);
+        $this->assertArrayHasKey('433e99fcfec5c3f50406f05705c209de', $result);
+        $this->assertArrayHasKey('c0f0564c18ec9468eae999f5416c2b35', $result);
     }
 
     /**


### PR DESCRIPTION
…cludes getting

the same message with different global message IDs.
To cope with this, this patch deduplicates messages by an md5 hash of the
message body. This deduplication happens at both when receiving messages
from the queue and when storing in the database.