### PR TITLE
Issue #168: Stopped error messages from being propogated

### DIFF
--- a/classes/task/extract_metadata.php
+++ b/classes/task/extract_metadata.php
@@ -257,7 +257,7 @@ class extract_metadata extends scheduled_task {
                     $metadatarecords[] = $metadatarecord;
                 } else {
                     $failcount++;
-                    $failhashses[] = $filehash->pathnamehash; // Record the failed hashes for logging.
+                    $failhashses[$filehash->pathnamehash] = $filemetadata['reason']; // Record the failed hashes for logging.
                 }
             }
 
@@ -317,8 +317,8 @@ class extract_metadata extends scheduled_task {
         mtrace('local_smartmedia: Number files successfully processed: ' . $processresults['successcount']);
         mtrace('local_smartmedia: Number files with process failures: ' . $processresults['failcount']);
         mtrace('local_smartmedia: ' . $processresults['duplicatecount'] . ' duplicate file entries were skipped.');
-        foreach ($processresults['failedhashes'] as $failedhash) {
-            mtrace('local_smartmedia: Failed to process file with hash: ' . $failedhash);
+        foreach ($processresults['failedhashes'] as $failedhash => $reason) {
+            mtrace('local_smartmedia: Failed to process file with hash: ' . $failedhash . ': ' . $reason);
         }
 
         // Remove files from metadata table.


### PR DESCRIPTION
Closes #168 . This patch does not currently flag files from being rerun, due to the possibility of a temporary issue, and it would require larger DB changes to support this for little gain