### PR TITLE
gracefully skip files that do not exist in the file store for whatever reason

### DIFF
--- a/classes/ffprobe.php
+++ b/classes/ffprobe.php
@@ -145,7 +145,10 @@ class ffprobe {
         // Write the file contents into a local tempfile not a moodle tempfile.
         $tempfile = tmpfile();
         $path = stream_get_meta_data($tempfile)['uri'];
-        $file->copy_content_to($path);
+        if (!$file->copy_content_to($path)) {
+            $metadata['reason'] = 'file does not exist';
+            return $metadata;
+        }
 
         // Execute the FFProbe command to get file metadata.
         $command = $this->ffprobe_path . ' -of json -v error -show_format -show_streams ' .  escapeshellarg($path);


### PR DESCRIPTION
if a file is corrupted or has been somehow deleted from the file store but still exists in the files table it will cause ffprobe to throw an error. we can catch this by checking the return of copy_content_to() and gracefully skip over the file.