### PR TITLE
Ensure non-pluginfile URLS are ignored

### DIFF
--- a/classes/conversion.php
+++ b/classes/conversion.php
@@ -367,6 +367,10 @@ class conversion {
         $argumentsstring = $href->get_path(true);
         $rawarguments = explode('/', $argumentsstring);
         $pluginfileposition = array_search('pluginfile.php', $rawarguments);
+        // Not a normalised pluginfile.php URL.
+        if ($pluginfileposition === false) {
+            return false;
+        }
         $hrefarguments = array_slice($rawarguments, ($pluginfileposition + 1));
         $argumentcount = count($hrefarguments);
 

--- a/tests/conversion_test.php
+++ b/tests/conversion_test.php
@@ -445,6 +445,22 @@ class local_smartmedia_conversion_testcase extends advanced_testcase {
         $this->assertEquals($filepathnamehash3, $result3->get_pathnamehash());
         $this->assertEquals($filepathnamehash4, $result4->get_pathnamehash());
         $this->assertEquals($filepathnamehash5, $result5->get_pathnamehash());
+
+        // Lets test a pluginfile-like URL that is incompatible.
+        $urlstr = implode('/', [
+            'tokenpluginfile.php',
+            'mycooltoken',
+            $file1->get_contextid(),
+            $file1->get_component(),
+            $file1->get_filearea(),
+            $file1->get_itemid()
+        ]);
+        // Now append the filepath and name without extra strings.
+        $urlstr .= $file1->get_filepath() . $file1->get_filename();
+        $tokenurl = new moodle_url($urlstr);
+
+        // This should return false.
+        $this->assertFalse($method->invoke($conversion, $tokenurl));
     }
 
     /**


### PR DESCRIPTION
There was a type coercion issue that could occur with pluginfile.php not being present, after which false would immediately coerce to 0, which would then lead to errors when attempting to query files. This can happen in the cases where the string `pluginfile.php` is included in the input URL, while not actually being a valid targetable URL. Specifically `tokenpluginfile.php` was picked up by filter regex. Instead of complicating the regex the fix here is to simply safeguard this function to ensure the URL is a valid URL we can action.